### PR TITLE
Suppress Build Changes Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ script:
 
 deploy:
   provider: script
+  skip_cleanup: true
   script: ./.travis/deploy.sh


### PR DESCRIPTION
Fixing #2 
Prevent Travis CI from resetting the working directory and deleting all changes made during the build.